### PR TITLE
Release 6.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ytmusic.js",
   "description": "Browser-side JS library for controlling YouTube Music",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "homepage": "https://github.com/gmusic-utils/ytmusic.js",
   "author": {
     "name": "Todd Wolfson",


### PR DESCRIPTION
Along with an actual publish to npm, will close https://github.com/gmusic-utils/ytmusic.js/issues/20